### PR TITLE
Random flips and a bunch of them

### DIFF
--- a/src/fliptable.coffee
+++ b/src/fliptable.coffee
@@ -36,5 +36,5 @@ module.exports = (robot) ->
       '┻━┻ ︵ ლ(⌒-⌒ლ)',
       'ʇǝʞɔɐɹq ︵ヽ(`Д´)ﾉ︵ ǝʞup'
     ]
-    msg.send flips[Math.floor(Math.random()*flips.length)]
+    msg.send msg.random flips
 


### PR DESCRIPTION
Removes the explicit `rage` and `set` subcommands and adds in ALL THE TABLE FLIPS. Flip will return a random flip, as it was always meant to be.
